### PR TITLE
mention Geyser-Standalone as a alternative for UDP in Playit Plugin.

### DIFF
--- a/wiki/geyser/playit-gg.md
+++ b/wiki/geyser/playit-gg.md
@@ -10,7 +10,7 @@ You must be able to connect to your Geyser instance locally!
 :::
 
 :::warning
-The playit.gg Minecraft server plugin does not support UDP tunnels. You will need to use the program agent instead!
+The playit.gg Minecraft server plugin does not support UDP tunnels. You will need to use the program agent instead, if you can't use the program, you have to use Geyser-Standalone and connect to your server with that!
 :::
 
 - If you already have playit.gg running & set up (for e.g. Minecraft Java edition), skip steps 1 and 2 and proceed with step 3.


### PR DESCRIPTION
if i cannot use UDP in playit plugin, then i can use localhost to connect using Geyser-Standalone pointing at my server as a alternative solution.

