### PR TITLE
Remove MCProHosting from providers list

### DIFF
--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -92,14 +92,6 @@ export const providersData: Providers = {
             })
         },
         {
-            name: 'MCProHosting',
-            url: 'https://mcprohosting.com/',
-            description: translate({
-                id: 'providers.provider.mcprohosting.description',
-                message: "Click 'Enable Bedrock Support' on the server dashboard and follow the steps. For manual installation: Add 'Destination Port' `19132` with 'Protocol UDP' to the port forward mapping and connect to the given source port."
-            })
-        },
-        {
             name: 'Minefort',
             url: 'https://minefort.com/',
             description: translate({


### PR DESCRIPTION
Evidently, the panel has officially migrated to the Apex panel, meaning these instructions are no longer relevant and impossible to perform. Users can view the Apex Hosting guide instead.