### PR TITLE
Update headings to avoid errors from MDXv2 parser

### DIFF
--- a/wiki/api/index.mdx
+++ b/wiki/api/index.mdx
@@ -6,7 +6,7 @@ description: 'These REST APIs provide web endpoints to query different informati
 
 import DocCardList from '@theme/DocCardList'
 
-# Overview of available REST APIs
+# Overview of available REST APIs \{#overview-of-available-rest-apis}
 
 Currently, there are two different Rest APIs you can use.
 

--- a/wiki/floodgate/setup/proxy-servers.mdx
+++ b/wiki/floodgate/setup/proxy-servers.mdx
@@ -14,7 +14,7 @@ Additionally, it will display Bedrock edition skins properly.
 3. Change `auth-type` in Geyser's config to `floodgate`.
 4. Restart the server.
 
-### Installing Floodgate on servers behind the proxy {#installing-floodgate-on-servers-behind-the-proxy}
+### Installing Floodgate on servers behind the proxy \{#installing-floodgate-on-servers-behind-the-proxy}
 
 This is only needed when you want to use the Floodgate API on your backend server(s) behind a proxy.
 

--- a/wiki/geyser/faq.mdx
+++ b/wiki/geyser/faq.mdx
@@ -6,7 +6,7 @@ description: Frequently asked questions about Geyser, including how it works, wh
 import { Questions, Q, A } from "@site/src/components/Questions";
 import { Versions } from '@site/src/components/Versions'
 
-### General Questions {#general-questions}
+### General Questions \{#general-questions}
 
 Here you can find answers to frequently asked questions about Geyser - if you have a question that isn't answered here, feel free to ask in our [Discord](https://discord.gg/GeyserMC)!
 
@@ -240,7 +240,7 @@ Here you can find answers to frequently asked questions about Geyser - if you ha
     </Q>
 </Questions>
 
-### Additional Questions {#additional-questions}
+### Additional Questions \{#additional-questions}
 
 These additional frequently asked questions are not related to Geyser gameplay.
 

--- a/wiki/geyser/index.mdx
+++ b/wiki/geyser/index.mdx
@@ -8,7 +8,7 @@ import { Versions } from '@site/src/components/Versions'
 import { useDocById } from '@docusaurus/plugin-content-docs/client'
 import DocCardList from '@theme/DocCardList'
 
-# Overview
+# Overview \{#overview}
 
 [//]: # ([![License: MIT]&#40;https://img.shields.io/badge/license-MIT-blue.svg?label=License&#41;]&#40;LICENSE&#41;)
 [![Build Status](https://github.com/GeyserMC/Geyser/actions/workflows/build.yml/badge.svg)](https://github.com/GeyserMC/Geyser/actions/workflows/build.yml)

--- a/wiki/geyser/setup/self/standalone.mdx
+++ b/wiki/geyser/setup/self/standalone.mdx
@@ -12,7 +12,7 @@ You need to have Java 17 or higher installed to run Geyser. To run Geyser Standa
 Geyser-Standalone is NOT a plugin or mod! It is a standalone Java program that you would run separately to your Java Edition server.
 :::
 
-### General Setup & Configuration {#general-setup--configuration}
+#### General Setup & Configuration \{#general-setup--configuration}
 
 1. Download Geyser Standalone from [here](/download).
 2. Create a new folder for Geyser, and drop the jar in there.
@@ -77,13 +77,13 @@ set it to either `online` for an online mode server, or `offline` for an offline
 
 6. Verify whether connections from other networks are possible by running `geyser connectiontest <ip> <port>` in the console.
 
-### Running Geyser-Standalone on Android {#running-geyser-standalone-on-android}
+#### Running Geyser-Standalone on Android \{#running-geyser-standalone-on-android}
 
 :::caution
 Applications such as Termux on Android are capable of running Geyser, but this largely depends on how powerful your Android device is. Please do so at your own risk.
 :::
 
-#### Termux (Android) {#termux-android}
+##### Termux (Android) \{#termux-android}
 1. Download and install [Termux](https://termux.com/)
 2. Run `pkg install openjdk-17`
 3. Run `wget https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone`

--- a/wiki/geyser/supported-hosting-providers.mdx
+++ b/wiki/geyser/supported-hosting-providers.mdx
@@ -29,14 +29,14 @@ The below information is for the plugin versions of Geyser unless otherwise spec
 
 :::
 
-## Built-in Geyser {#built-in-geyser}
+## Built-in Geyser \{#built-in-geyser}
 
 <Provider type="built_in" />
 
-## Support for Geyser {#support-for-geyser}
+## Support for Geyser \{#support-for-geyser}
 
 <Provider type="support" />
 
-## Does not support Geyser {#does-not-support-geyser}
+## Does not support Geyser \{#does-not-support-geyser}
 
 <Provider type="no_support" />

--- a/wiki/index.mdx
+++ b/wiki/index.mdx
@@ -6,7 +6,7 @@ description: 'This page provides an overview over all sections of the GeyserMC w
 
 import DocCardList from '@theme/DocCardList'
 
-# Overview
+# Overview \{#overview}
 
 The GeyserMC wiki offers guides on different projects. Select the one you are interested in below!
 

--- a/wiki/other/index.mdx
+++ b/wiki/other/index.mdx
@@ -7,7 +7,7 @@ description: 'Other projects or guides not directly referring to Geyser or Flood
 import DocCardList from '@theme/DocCardList'
 import { useDocById } from '@docusaurus/plugin-content-docs/client'
 
-# Overview of Other projects
+# Overview of Other projects \{#overview-of-other-projects}
 
 The "other" category provides you with information about different projects that are not Geyser or Floodgate.
 This includes community projects, but also other projects by the GeyserMC team, such as Hurricane or Hydraulic.


### PR DESCRIPTION
- Updates headings to avoid errors from MDXv2 parser (see https://github.com/facebook/docusaurus/issues/9155#issuecomment-1642550770)
- Adds missing explicit anchor definitions
- Increases subhead level for self standalone setup headings to prevent them from showing in the sidebar on other tabs

The anchor changes are part of preparing for using Crowdin for i18n.