### PR TITLE
Remove and Replace "TydiumCraft Skin API"

### DIFF
--- a/wiki/other/community-geyser-projects.md
+++ b/wiki/other/community-geyser-projects.md
@@ -117,8 +117,8 @@ Small application that waits for a player to connect before launching actual min
 
 Creator: [Vincss](https://github.com/vincss)
 
-## TydiumCraft Skin API {#tydiumcraft-skin-api}
-An API makes it easier for your Bedrock skin to be rendered and outputted!
-* [Website](https://tydiumcraft.net/api)
+## Starlight Skin API {#starlight-skin-api}
+An updated API that makes it easier for Bedrock Skins to be outputted. 
+* [Website](https://lunareclipse.studio/creations/starlight-skinapi)
 
-Creators: [Tydium](https://github.com/Tydium)
+Creators: [Bret06](https://www.bret06.net/)

--- a/wiki/other/community-geyser-projects.md
+++ b/wiki/other/community-geyser-projects.md
@@ -118,7 +118,7 @@ Small application that waits for a player to connect before launching actual min
 Creator: [Vincss](https://github.com/vincss)
 
 ## Starlight Skin API {#starlight-skin-api}
-An updated API that makes it easier for Bedrock Skins to be outputted. 
+An API that makes it easier for Bedrock Skins to be outputted. 
 * [Website](https://lunareclipse.studio/creations/starlight-skinapi)
 
 Creators: [Bret06](https://www.bret06.net/)


### PR DESCRIPTION
I no longer will run TydiumCraft Skin API. I have no interest in continuing it at this time (or anything minecraft related). However I have switched out the spot with an API that 100% is always updated and active. Hosted by my good friend Bret06. This works so much better as well. Thanks for everything over the years guys! It's been a ton of fun spending moments with you guys. Tydium out!