### PR TITLE
Add Play Hosting to providers list

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -44,6 +44,9 @@
   "providers.provider.lilypad.description": {
     "message": "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [lilypad.gg/bedrock](https://lilypad.gg/bedrock)."
   },
+  "providers.provider.playhosting.description": {
+    "message": "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [help.play.hosting/minecraft/crossplay](https://help.play.hosting/minecraft/crossplay)."
+  },
   "providers.provider.mcprohosting.description": {
     "message": "Click 'Enable Bedrock Support' on the server dashboard and follow the steps. For manual installation: Add 'Destination Port' `19132` with 'Protocol UDP' to the port forward mapping and connect to the given source port."
   },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -44,9 +44,6 @@
   "providers.provider.lilypad.description": {
     "message": "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [lilypad.gg/bedrock](https://lilypad.gg/bedrock)."
   },
-  "providers.provider.playhosting.description": {
-    "message": "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [help.play.hosting/minecraft/crossplay](https://help.play.hosting/minecraft/crossplay)."
-  },
   "providers.provider.mcprohosting.description": {
     "message": "Click 'Enable Bedrock Support' on the server dashboard and follow the steps. For manual installation: Add 'Destination Port' `19132` with 'Protocol UDP' to the port forward mapping and connect to the given source port."
   },
@@ -56,11 +53,14 @@
   "providers.provider.minehut.description": {
     "message": "Connect via `bedrock.minehut.com` and do `/join [servername]`, or connect directly via `[servername].bedrock.minehut.gg`."
   },
+  "providers.provider.omgserv.description": {
+    "message": "Select Geyser in the [Install Menu](https://i.imgur.com/Gewpsrq.png), it will be automatically installed. You can enable floodgate in the [server properties on the dashboard](https://i.imgur.com/jg5mzNj.png)."
+  },
   "providers.provider.piglinhost.description": {
     "message": "Order from the [cross-platform servers page](https://piglinhost.com/minecraft-java-hosting.html). Alternatively, contact their support by creating a [support ticket](https://billing.piglinhost.com/submitticket.php?step=2&deptid=5) or via discord for installation and configuration help."
   },
-  "providers.provider.omgserv.description": {
-    "message": "Select Geyser in the [Install Menu](https://i.imgur.com/Gewpsrq.png), it will be automatically installed. You can enable floodgate in the [server properties on the dashboard](https://i.imgur.com/jg5mzNj.png)."
+  "providers.provider.playhosting.description": {
+    "message": "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [help.play.hosting/minecraft/crossplay](https://help.play.hosting/minecraft/crossplay)."
   },
   "providers.provider.pufferfish_host.description": {
     "message": "Geyser is installed and configured on all servers by default."

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -97,6 +97,14 @@ export const providersData: Providers = {
             })
         },
         {
+            name: 'Play Hosting',
+            url: 'https://play.hosting',
+            description: translate({
+                id: 'providers.provider.playhosting.description',
+                message: "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [help.play.hosting/minecraft/crossplay](https://help.play.hosting/minecraft/crossplay)."
+            })
+        },
+        {
             name: 'MCServerHost',
             url: 'https://mcserverhost.com/',
             description: translate({

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -97,14 +97,6 @@ export const providersData: Providers = {
             })
         },
         {
-            name: 'Play Hosting',
-            url: 'https://play.hosting',
-            description: translate({
-                id: 'providers.provider.playhosting.description',
-                message: "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [help.play.hosting/minecraft/crossplay](https://help.play.hosting/minecraft/crossplay)."
-            })
-        },
-        {
             name: 'MCServerHost',
             url: 'https://mcserverhost.com/',
             description: translate({
@@ -129,6 +121,14 @@ export const providersData: Providers = {
             })
         },
         {
+            name: 'OMGServ',
+            url: 'https://www.omgserv.com/en/',
+            description: translate({
+                id: 'providers.provider.omgserv.description',
+                message: "Select Geyser in the [Install Menu](https://i.imgur.com/Gewpsrq.png), it will be automatically installed. You can enable floodgate in the [server properties on the dashboard](https://i.imgur.com/jg5mzNj.png)."
+            })
+        },
+        {
             name: 'Physgun',
             url: 'https://physgun.com/',
             description: descriptionTemplates.default
@@ -142,11 +142,11 @@ export const providersData: Providers = {
             })
         },
         {
-            name: 'OMGServ',
-            url: 'https://www.omgserv.com/en/',
+            name: 'Play Hosting',
+            url: 'https://play.hosting',
             description: translate({
-                id: 'providers.provider.omgserv.description',
-                message: "Select Geyser in the [Install Menu](https://i.imgur.com/Gewpsrq.png), it will be automatically installed. You can enable floodgate in the [server properties on the dashboard](https://i.imgur.com/jg5mzNj.png)."
+                id: 'providers.provider.playhosting.description',
+                message: "Tick the 'Enable Bedrock crossplay?' option when changing your server software to automatically install and configure Geyser + Floodgate. For more details, navigate to [help.play.hosting/minecraft/crossplay](https://help.play.hosting/minecraft/crossplay)."
             })
         },
         {


### PR DESCRIPTION
**Website:** https://play.hosting
**Crossplay documentation:** https://help.play.hosting/minecraft/crossplay

Since Play Hosting is managed by Lilypad + Tubbo, the process for enabling Geyser is the same as Lilypad