### PR TITLE
Add extensions page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -146,6 +146,12 @@ const config: Config = {
                         }
                     ]
                 },
+                 {
+                    to: 'extensions',
+                    label: 'Extensions',
+                    position: 'left',
+                    className: 'header-extensions-link'
+                },
                 {
                     to: 'download',
                     label: 'Download',

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -245,6 +245,12 @@
   "pages.download.description.thirdpartycosmetics": {
     "message": "An extension that adds support for loading ears and other third party cosmetics on java players"
   },
+  "pages.extensions.title": {
+    "message": "Extensions"
+  },
+  "pages.extensions.subheading": {
+    "message": "A list of known Geyser extensions."
+  },
   "pages.configeditor.noconfigselected.heading": {
     "message": "No config selected."
   },

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -98,6 +98,10 @@ html[data-theme='dark'] {
     @include header-link(24px, 24px, url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M288 32c0-17.7-14.3-32-32-32s-32 14.3-32 32V274.7l-73.4-73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L288 274.7V32zM64 352c-35.3 0-64 28.7-64 64v32c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V416c0-35.3-28.7-64-64-64H346.5l-45.3 45.3c-25 25-65.5 25-90.5 0L165.5 352H64zm368 56a24 24 0 1 1 0 48 24 24 0 1 1 0-48z"/></svg>'));
 }
 
+.header-extensions-link {
+    @include header-link(24px, 24px, url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2024 Fonticons, Inc. --><path d="M192 104.8c0-9.2-5.8-17.3-13.2-22.8C167.2 73.3 160 61.3 160 48c0-26.5 28.7-48 64-48s64 21.5 64 48c0 13.3-7.2 25.3-18.8 34c-7.4 5.5-13.2 13.6-13.2 22.8c0 12.8 10.4 23.2 23.2 23.2l56.8 0c26.5 0 48 21.5 48 48l0 56.8c0 12.8 10.4 23.2 23.2 23.2c9.2 0 17.3-5.8 22.8-13.2c8.7-11.6 20.7-18.8 34-18.8c26.5 0 48 28.7 48 64s-21.5 64-48 64c-13.3 0-25.3-7.2-34-18.8c-5.5-7.4-13.6-13.2-22.8-13.2c-12.8 0-23.2 10.4-23.2 23.2L384 464c0 26.5-21.5 48-48 48l-56.8 0c-12.8 0-23.2-10.4-23.2-23.2c0-9.2 5.8-17.3 13.2-22.8c11.6-8.7 18.8-20.7 18.8-34c0-26.5-28.7-48-64-48s-64 21.5-64 48c0 13.3 7.2 25.3 18.8 34c7.4 5.5 13.2 13.6 13.2 22.8c0 12.8-10.4 23.2-23.2 23.2L48 512c-26.5 0-48-21.5-48-48L0 343.2C0 330.4 10.4 320 23.2 320c9.2 0 17.3 5.8 22.8 13.2C54.7 344.8 66.7 352 80 352c26.5 0 48-28.7 48-64s-21.5-64-48-64c-13.3 0-25.3 7.2-34 18.8C40.5 250.2 32.4 256 23.2 256C10.4 256 0 245.6 0 232.8L0 176c0-26.5 21.5-48 48-48l120.8 0c12.8 0 23.2-10.4 23.2-23.2z"/></svg>'));
+}
+
 .header-github-link {
     @include header-link(24px, 24px, url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E"));
 }
@@ -344,4 +348,45 @@ html[data-theme='dark'] {
         border-radius: var(--ifm-global-radius);
         color: #fff
     }
+}
+
+.extension-button {
+   padding: 10px;
+}
+
+.extension-button:hover {
+    text-decoration: none;
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.extension-button:not(:last-child) {
+    border-bottom: 1px solid var(--ifm-horizontal-line-color);
+}
+
+.extension-name {
+    font-size: 22px;
+    font-weight: bold;
+}
+
+.extension-author {
+    margin-top: auto;
+}
+
+.extension-button-header {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 0;
+}
+
+.extension-badge {
+    background-color: green;
+    color: white;
+    font-size: 14px;
+    font-weight: bold;
+    padding: 1px 8px;
+    border-radius: 10px;
+}
+
+.mt-20 {
+    margin-top: 20px;
 }

--- a/src/data/extensions.json
+++ b/src/data/extensions.json
@@ -1,0 +1,86 @@
+[
+    {
+        "name": "EmoteMenu",
+        "description": "Creates a quick menu for easy access for Geyser features and command execution, even with Xbox Achievements turned on.",
+        "author": "Carbuino",
+        "official": false,
+        "url": "https://github.com/Carbuino/EmoteMenu"
+    },
+    {
+        "name": "GeyserConnect",
+        "description": "Allows you to host a GeyserConnect instance to connect to any Java server, with or without Geyser. Like Geyser Standalone on steroids.",
+        "author": "GeyserMC",
+        "official": true,
+        "url": "https://github.com/GeyserMC/GeyserConnect"
+    },
+    {
+        "name": "GeyserFloatingPoints",
+        "description": "An extension that adds a hacky workaround to fix floating-point precision at large distances (Bedrock distance effect).",
+        "author": "Oryxel",
+        "official": false,
+        "url": "https://github.com/Oryxel/GeyserFloatingPoints"
+    },
+    {
+        "name": "HideCommands",
+        "description": "Allows you to hide Java commands from Bedrock players.",
+        "author": "Redned235",
+        "official": true,
+        "url": "https://github.com/Redned235/HideCommands"
+    },
+    {
+        "name": "Jukebox Extended Reborn",
+        "description": "Level up your server with custom music discs. Allows JEXT to work with Geyser standalone.",
+        "author": "Spartacus04",
+        "official": false,
+        "url": "https://github.com/spartacus04/jext-reborn"
+    },
+    {
+        "name": "LuckLink",
+        "description": "A LuckPerms integration that automatically registers permissions for Geyser and Geyser extensions on platforms where there is no built-in permission manager. These include Fabric, Velocity, and BungeeCord. Also requires LuckPerms to be installed.",
+        "author": "onebeastchris",
+        "official": true,
+        "url": "https://github.com/onebeastchris/LuckLink"
+    },
+    {
+        "name": "MagicMenu",
+        "description": "Allows you to run custom commands with forms & quick accessing them with emotes.",
+        "author": "onebeastchris",
+        "official": true,
+        "url": "https://github.com/onebeastchris/MagicMenu"
+    },
+    {
+        "name": "MCXboxBroadcast",
+        "description": "Creates & hosts a simple friend bot to connect to your Geyser server. Makes joining Geyser servers on consoles super easy!",
+        "author": "rtm516",
+        "official": true,
+        "url": "https://github.com/MCXboxBroadcast/Broadcaster"
+    },
+    {
+        "name": "PickPack",
+        "description": "Allows Bedrock players to choose & toggle their resource packs while playing on your server!",
+        "author": "onebeastchris",
+        "official": true,
+        "url": "https://github.com/onebeastchris/pickpack/"
+    },
+    {
+        "name": "Spark",
+        "description": "A Spark implementation for Geyser-Standalone. Can be used to create performance profiles, heap dumps, and general health reporting. Note; a download is not yet available so you would need to compile it yourself.",
+        "author": "GeyserMC",
+        "official": true,
+        "url": "https://github.com/GeyserMC/spark"
+    },
+    {
+        "name": "ThirdPartyCosmetics",
+        "description": "Adds support for third-party capes and ears to Geyser.",
+        "author": "GeyserMC",
+        "official": true,
+        "url": "https://github.com/GeyserMC/ThirdPartyCosmetics"
+    },
+    {
+        "name": "TransferTool",
+        "description": "Allows you to configure Geyser servers to send a player to when Geyser receives a Java transfer packet.",
+        "author": "onebeastchris",
+        "official": true,
+        "url": "https://github.com/onebeastchris/TransferTool"
+    }
+]

--- a/src/pages/extensions.tsx
+++ b/src/pages/extensions.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import HeroBanner from '@site/src/components/HeroBanner';
+import HeroBackground from '@site/static/img/site/split-background.webp';
+import Layout from '@theme/Layout';
+import Admonition from '@theme/Admonition';
+import Translate from '@docusaurus/Translate';
+import { Grid } from '../components/Grid';
+import extensionsData from '@site/src/data/extensions.json';
+
+type Extension = {
+    name: string;
+    description: string;
+    author: string;
+    official: boolean;
+    url: string;
+};
+
+const extensions: Extension[] = extensionsData as Extension[];
+
+const ExtensionsPage: React.FC = () => (
+    <>
+        <HeroBanner
+            title={<Translate id='pages.extensions.title'>Extensions</Translate>}
+            subheading={<Translate id='pages.extensions.subheading'>A list of known Geyser extensions.</Translate>}
+            backgroundImage={HeroBackground}
+        />
+
+        <Admonition type="warning" className="mt-20">
+            Some of these extensions are not maintained by the GeyserMC team and as such should be used with caution. Extensions marked "Official Extension" are maintained by at least one member of the core GeyserMC team.
+        </Admonition>
+    
+        <div className="mt-20">
+            <Grid elementsPerRow={1}>
+                {extensions.map((extension) => (
+                    <a key={extension.name} href={extension.url} className="extension-button">
+                        <div className="extension-button-header">
+                            <span className="extension-name">{extension.name}</span>
+                            <span className="extension-author">by {extension.author}</span>
+                        </div>
+                        {extension.official && <span className="extension-badge">Official Extension</span>}
+                        <div className="extension-description">{extension.description}</div>
+                    </a>
+                ))}
+            </Grid>
+        </div>
+    </>
+);
+
+export default function Extensions(): JSX.Element {
+    return (
+        <Layout
+            title={`Extensions`}
+            description="A list of Geyser extensions."
+        >
+            <main>
+                <div className="container container--fluid margin-vert--lg">
+                    <ExtensionsPage />
+                </div>
+            </main>
+        </Layout>
+    )
+}
+


### PR DESCRIPTION
This PR experiments with adding a page dedicated to known extensions, rather than having a [separate GitHub repo](https://github.com/GeyserMC/GeyserExtensionList), as this is easier for the average user to find extensions.

In the future, as the extension ecosystem grows, it may be a good idea to expand on this, but for now with only a few extensions I think this is a good idea.

Please let me know what you think.

![screencapture-localhost-3000-extensions-2025-06-03-03_17_11 (1)](https://github.com/user-attachments/assets/53051078-f23d-4478-bfa7-4bdddf696e7b)
