### PR TITLE
Add Hydraulic and Rainbow onto the download page

### DIFF
--- a/src/components/ProjectDownload.tsx
+++ b/src/components/ProjectDownload.tsx
@@ -16,9 +16,10 @@ interface ProjectDownloadProps {
         [key: string]: { url: string, file: string };
     };
     gridColumns?: number;
+    warning?: React.ReactNode;
 }
 
-export const ProjectDownload: React.FC<ProjectDownloadProps> = ({ projectId, description, setup, downloadsInfo, additionalDownloads, gridColumns }) => {
+export const ProjectDownload: React.FC<ProjectDownloadProps> = ({ projectId, description, setup, downloadsInfo, additionalDownloads, gridColumns, warning }) => {
     const [platformInfo, setPlatformInfo] = useState<Downloads.Builds>({
         project_id: '',
         project_name: '',
@@ -79,6 +80,11 @@ export const ProjectDownload: React.FC<ProjectDownloadProps> = ({ projectId, des
                 <Column>
                     <h3>Build #{latestBuild.build} · {new Date(latestBuild.time).toLocaleDateString()}:</h3>
                     <Grid elementsPerRow={gridColumns || 2} gap="8px">
+                        { warning && 
+                            <div className='warning-box'>
+                                { warning }
+                            </div>
+                        }
                         { setup &&
                             <a href={setup} className='no-underline setup-button large-button'>
                                 <b><FontAwesomeIcon icon={faBook}/> Setup Instructions</b>

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -16,6 +16,7 @@
     --ifm-color-primary-light: #33925d;
     --ifm-color-primary-lighter: #359962;
     --ifm-color-primary-lightest: #3cad6e;
+    --ifm-color-warning: #e4f126;
     --ifm-code-font-size: 95%;
     --ifm-footer-color: rgb(238, 249, 253);
     --ifm-footer-background-color: #303846;
@@ -301,6 +302,15 @@ html[data-theme='dark'] {
         background-color: var(--ifm-color-secondary);
         color: #fff;
     }
+}
+
+.warning-box {
+    width: 100%;
+    border-left: 3px solid var(--ifm-color-warning);
+    text-align: center;
+    font-size: 18px;
+    padding-top: 5px;
+    padding-bottom: 5px;
 }
 
 .tabs {

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -129,7 +129,22 @@ const DownloadPage: React.FC = () => (
                             />
                         }
                     />
-{/*                     <Collapsible
+                    <Collapsible
+                        title='Rainbow'
+                        subtitle={<Translate id='pages.download.description.rainbow'>A Minecraft mod to generate Geyser item mappings and bedrock resourcepacks for use with Geyser's custom item API (v2). </Translate>}
+                        id='rainbow'
+                        tags={['Beta']}
+                        inner={
+                            <ProjectDownload
+                                projectId="rainbow"
+                                downloadsInfo={{
+                                    rainbow: <PlatformIcon img={FabricIcon} text="Fabric" />,
+                                }}
+                                gridColumns={1}
+                            />
+                        }
+                    />
+                    <Collapsible
                         title='Hydraulic'
                         subtitle={<Translate id='pages.download.description.hydraulic'>A companion mod to Geyser which allows for Bedrock players to join modded Minecraft: Java Edition servers.</Translate>}
                         id='hydraulic'
@@ -143,9 +158,21 @@ const DownloadPage: React.FC = () => (
                                     neoforge: <PlatformIcon img={NeoForgeIcon} text="NeoForge" />,
                                 }}
                                 gridColumns={1}
+                                warning={ // Remove when Item API V2 is merged!
+                                    <>
+                                        <Translate id='pages.download.warning.hydraulic'>
+                                           A preview version of Geyser is required to run Hydraulic, you can download the Item API V2 preview below:
+                                        </Translate>
+                                        <p>
+                                           <a href="https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5189/builds/latest/downloads/fabric">Fabric</a>
+                                           <span>, </span>
+                                           <a href="https://download.geysermc.org/v2/projects/geyserpreview/versions/pr.5189/builds/latest/downloads/neoforge">NeoForge</a>
+                                        </p>
+                                    </>
+                                }
                             />
                         }
-                    /> */}
+                    />
                 </Collapsibles>
             </TabItem>
         </Tabs>


### PR DESCRIPTION
Title + adds a warning on the Hydraulic download telling users the Item API V2 preview is required and provide download links to it for Fabric and NeoForge