### PR TITLE
Remove Geyser Android App and Tempest

### DIFF
--- a/wiki/geyser/using-geyser-with-consoles.md
+++ b/wiki/geyser/using-geyser-with-consoles.md
@@ -65,12 +65,10 @@ If you have a PC, you can use [Phantom](https://github.com/jhead/phantom).
 
 ### Using an Android Device {#using-an-android-device}
 If you have an Android device, you have several options:
-- ~~[Geyser Android app](https://github.com/GeyserMC/GeyserAndroid)~~ (Discontinued)
 - [BedrockTogether](https://play.google.com/store/apps/details?id=pl.extollite.bedrocktogetherapp)
 - [MC Lan Proxy (Trial)](https://play.google.com/store/apps/details?id=com.luzenna.mineproxydroidtrial)
 - [MC Lan Proxy (Paid)](https://play.google.com/store/apps/details?id=com.luzenna.mineproxydroid)
 - [MC Server Connector](https://play.google.com/store/apps/details?id=com.smokiem.mcserverconnector)
-- [Tempest](https://play.google.com/store/apps/details?id=net.ahmed.tempest)
 
 ### Using an iOS device {#using-an-ios-device}
 If you have an iOS 14+ device, you can use [BedrockTogether](https://apps.apple.com/app/bedrocktogether/id1534593376).


### PR DESCRIPTION
The Using Geyser with Consoles wiki page should no longer include the Geyser Android App and Tempest. The Geyser Android App is discontinued and should be removed entirely, rather than remaining as a crossed-out option for Android. Tempest has been deleted from the Google Play Store based on the Tempest link sending you to a Not Found page. So, Tempest should also be removed entirely.