### PR TITLE
Fix incorrect Ubuntu on Oracle Cloud instructions

### DIFF
--- a/wiki/geyser/port-forwarding.md
+++ b/wiki/geyser/port-forwarding.md
@@ -184,7 +184,8 @@ sudo firewall-cmd --reload
 #### Ubuntu {#ubuntu}
 
 1. Remove/comment out `-A INPUT -j REJECT --reject-with icmp-host-prohibited` in the `/etc/iptables/rules.v4` file.
-2. Run the following command to fix `ufw`:
-```bash 
-sudo iptables-restore < /etc/iptables/rules.v4
+2. Run the following commands to fix `ufw`:
+```bash
+sudo -i
+iptables-restore < /etc/iptables/rules.v4
 ```


### PR DESCRIPTION
```bash
sudo iptables-restore < /etc/iptables/rules.v4
```
will attempt to read `/etc/iptables/rules.v4` as the current user and pass it as `stdin` to `sudo iptables-restore`. This won't work as the current user likely doesn't have permission to read `/etc/iptables/rules.v4`. Instead, we should become the `root` user first with `sudo -i` then run the `iptables` command.