### PR TITLE
Added "Failed to ping the remote Java server" on the common issue page and restructured the page

### DIFF
--- a/wiki/geyser/common-issues.md
+++ b/wiki/geyser/common-issues.md
@@ -9,10 +9,10 @@ Commonly, people may have issues with Geyser not showing up in their server list
 This page contains a few common issues people may encounter that you might have as well as potential fixes for them. 
 If you still can't make it work, join [our Discord](https://discord.gg/geysermc) for support.
 
-# Floodgate
+## Floodgate
 For Floodgate issues see: [Floodgate: Known Issues/Caveats](/wiki/floodgate/issues/).
 
-# I can't connect! (Either the server doesn't show up in the friends list or I get "Unable to connect to world")
+## I can't connect! (Either the server doesn't show up in the friends list or I get "Unable to connect to world")
 * If you don't use a reverse proxy such as TCPShield make sure that `advanced.java.use-haproxy-protocol` is set to false.
 To fix "Unable to connect to world" with no console errors, see [here](/wiki/geyser/fixing-unable-to-connect-to-world/).
 
@@ -32,14 +32,14 @@ See [here](/wiki/geyser/fixing-unable-to-connect-to-world/) for fixing "Unable t
 
 :::
 
-### `java.net.BindException: Address already in use: bind` on startup. {#javanetbindexception-address-already-in-use-bind-on-startup}
+## `java.net.BindException: Address already in use: bind` on startup. {#javanetbindexception-address-already-in-use-bind-on-startup}
 This means something (likely another instance of Geyser) is running on the port you have specified in the config. Please make sure you close all applications running on this port. If you don't recall opening anything, usually restarting your computer fixes this.
 
-### [...]` has been compiled by a more recent version of the Java Runtime (class file version 60.0)` {#-has-been-compiled-by-a-more-recent-version-of-the-java-runtime-class-file-version-600}
+## [...]` has been compiled by a more recent version of the Java Runtime (class file version 60.0)` {#-has-been-compiled-by-a-more-recent-version-of-the-java-runtime-class-file-version-600}
 
 See this link for updating to Java 17: https://docs.papermc.io/misc/java-install.
 
-### Hosting provider will not immediately open up UDP. {#hosting-provider-will-not-immediately-open-up-udp}
+## Hosting provider will not immediately open up UDP. {#hosting-provider-will-not-immediately-open-up-udp}
 
 These steps only apply for the standalone version of Geyser.
 This usually has something to do on your host's end. Most commonly, it's because they do not open up ports over the UDP protocol, which is what Minecraft: Bedrock Edition uses, opposed to Minecraft: Java Edition using TCP. 
@@ -47,7 +47,7 @@ One way to get around this (if you're using an online host) is to shut down your
 
 **PLEASE NOTE:** If your server automatically redownloads jars upon startup, such as with an autoupdate system, this workaround will not work. Please contact your host if this does not work for you as there is nothing we can do.
 
-# Stuck on "Locating Server" with no errors
+## Stuck on "Locating Server" with no errors
 
 You may need to update your Java version. If so, update at [Adoptium.net](https://adoptium.net/).
 
@@ -55,11 +55,29 @@ Sometimes this happens in poor-network environments. There is an `advanced.bedro
 
 This option will most likely not help if you are getting "Unable to Connect to World" with no console logs indicating a connection.
 
-# Login Failed
+## Failed to ping the remote Java server
+
+One issue that you can encounter when starting your server with Geyser is eanbled is several occurences of  messages similar to the following.
+
+```
+[23:59:55] [Geyser Scheduled Thread-2-1/WARN]: [Geyser-Spigot] Failed to ping the remote Java server! Is it online and configured in Geyser's config?
+```
+
+Such type of message could be caused by incorrect settings in your floodgate setup, but it could also be due to your server MOTD being to long or your server-icon.png being to large. You should see an message similar to the bellow if that is the case.
+
+```
+String too big (was 38210 characters, max 32767)
+```
+
+Another symptom is that your Minecraft client will be unable to ping your server and that you won't see the player count in the server list.
+
+The way to fix this issue is to make sure that your MOTD is of an acceptable length and that your server-icon.png have a sensible file size. RGB (without alpha channel) and 8 bit bit depth when creating your server-icon.png will help reduce the file size.
+
+## Login Failed
 
 ***If you are using a plugin version:*** in your Geyser config, set your remote address to `127.0.0.1`. If that does not work, check your startup log for a message about Docker, and use that address in the remote address
 
-### Cannot reply to EncryptionRequestPacket without profile and access token {#cannot-reply-to-encryptionrequestpacket-without-profile-and-access-token}
+## Cannot reply to EncryptionRequestPacket without profile and access token {#cannot-reply-to-encryptionrequestpacket-without-profile-and-access-token}
 
 There are two causes of this message:
 
@@ -71,43 +89,43 @@ This message can occur with a Floodgate setup. Usually, it means that a misconfi
 
 If you have your configuration set up like this, put simply, it won't work. If authentication for the Java server is set to online, it is expected Geyser is configured the same way. The server requires a valid Minecraft: Java Edition account, and if you aren't logging into one with Geyser, then you will be unable to join the server. If your configuration is set up properly and you're still getting this issue, it could be that your credentials are invalid.
 
-### Connection Refused: \<INSERT IP AND/OR DOMAIN\> {#connection-refused-insert-ip-andor-domain}
+## Connection Refused: \<INSERT IP AND/OR DOMAIN\> {#connection-refused-insert-ip-andor-domain}
 
 Connection Refused usually means that a Java server could not be found on that port, or the server denied access to the connection on a network level. 
 The latter can happen with anti-DDOS plugins such as TCPShield, but otherwise ensure that the server you're trying to connect to is spelled correctly in the config, is up and is port forwarded correctly.
 
-### Floodgate Misconfiguration {#floodgate-misconfiguration}
+## Floodgate Misconfiguration {#floodgate-misconfiguration}
 See [this page](/wiki/floodgate/setup/) for more information.
 
-### Missing profile key. This server requires secure profiles. {#missing-profile-key-this-server-requires-secure-profiles}
+## Missing profile key. This server requires secure profiles. {#missing-profile-key-this-server-requires-secure-profiles}
 
 See [this page](/wiki/geyser/secure-chat/).
 
-### Mojang Resetting Account Credentials {#mojang-resetting-account-credentials}
+## Mojang Resetting Account Credentials {#mojang-resetting-account-credentials}
 This is unfortunately something we have no control over, and is most likely the case when you're running Geyser as a plugin on a server host or joining a friend far away from your location. If you're running Geyser locally, this should not happen to you, but what we recommend for servers is a plugin we make called [Floodgate](https://github.com/GeyserMC/Floodgate), which allows for Bedrock clients to join your server without needing a Java Edition account. Take a look [here](/wiki/floodgate) for more information.
 
-# "Invalid IP address!" from Bedrock
+## "Invalid IP address!" from Bedrock
 This can happen if the domain you are entering resolves to a SRV record, which Bedrock does not support. Try using the IPv4 address instead.
 Additionally, this can happen when trying to specify both the ip and port in the ip tab - in which case, see [here](/img/wiki/edit_server_form.png) for how to properly connect to "test.geysermc.org:19132".
 
-# Bedrock clients freeze when opening up commands for the first time
+## Bedrock clients freeze when opening up commands for the first time
 Disable `command-suggestions` in your Geyser config. This will stop the freezing at the expense of removing command suggestions from Bedrock clients.
 If you're a dedicated server admin, you can have a list of commands players should be using. This will remove any unnecessary commands from tab completion as well for Java players. 
 It has other benefits too. Here's a plugin that can just do that: 
 [CommandWhitelist](https://www.spigotmc.org/resources/81326/). Alternatively, use the [HideCommands](https://github.com/Redned235/HideCommands) Geyser extension to hide commands just for Bedrock players.
 
-# Failed to load locale asset cache: Unrecognized token 'Cannot'
+## Failed to load locale asset cache: Unrecognized token 'Cannot'
 This or anything else related to failing to download a locale file on startup is usually caused by java trying to connect using IPv6 and Mojang only use IPv4, so start Geyser or the server up with this flag `-Djava.net.preferIPv4Stack=true`, EG: `java -Xms1024M -Djava.net.preferIPv4Stack=true -jar Geyser.jar`
 
-# Outdated client! Please use 1.x.x
+## Outdated client! Please use 1.x.x
 
 The server is too new or Geyser is outdated. Make sure you're on the latest Geyser.
 
-# Outdated server! I'm still on 1.x.x
+## Outdated server! I'm still on 1.x.x
 
 Update the server or ask them to install [ViaVersion](https://viaversion.com/). You can also try [VIAaaS](https://github.com/ViaVersion/VIAaaS) (ViaVersion as a Service).
 
-# Only for BungeeCord with floodgate
+## Only for BungeeCord with floodgate
 
 If you use floodgate ensure that it is installed on all of your Spigot backend servers as following:
 
@@ -122,5 +140,5 @@ And so on.
 
 If your players can't connect from the lobby to another backend server, check console.
 
-### Plugins that can cause issues {#plugins-that-can-cause-issues}
+## Plugins that can cause issues {#plugins-that-can-cause-issues}
 * `HamsterAPI`


### PR DESCRIPTION
The basis for this change is that I have recently encountered an issue that can be a bit challenging to investigate as it might not be obvious what the problem is when the error message `String too big (was 38210 characters, max 32767)` drowns in a larger message that starts with  `Failed to ping the remote Java server`. I have tried to keep the text and fix for the issue as short and consistent as possible.

I also decided to do some changes to the order of items on the page and also what type of heading they are to get a more sensible TOC on the page.

Does this make sense or should it be located elsewhere?