### PR TITLE
Clarifying the version requirements by swapping "not running" to "running a version older than"

### DIFF
--- a/wiki/geyser/setup/provider/paper-spigot.mdx
+++ b/wiki/geyser/setup/provider/paper-spigot.mdx
@@ -7,7 +7,7 @@ hide_title: true
 import { Versions } from '@site/src/components/Versions'
 
 :::info
-If your server is not running <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
+If your server running a version earlier than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
 See also [this page](/wiki/geyser/supported-versions/) on supported versions.
 :::
 

--- a/wiki/geyser/setup/provider/paper-spigot.mdx
+++ b/wiki/geyser/setup/provider/paper-spigot.mdx
@@ -7,7 +7,7 @@ hide_title: true
 import { Versions } from '@site/src/components/Versions'
 
 :::info
-If your server is running a version earlier than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
+If your server is running a version older than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
 See also [this page](/wiki/geyser/supported-versions/) on supported versions.
 :::
 

--- a/wiki/geyser/setup/provider/paper-spigot.mdx
+++ b/wiki/geyser/setup/provider/paper-spigot.mdx
@@ -7,7 +7,7 @@ hide_title: true
 import { Versions } from '@site/src/components/Versions'
 
 :::info
-If your server running a version earlier than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
+If your server is running a version earlier than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
 See also [this page](/wiki/geyser/supported-versions/) on supported versions.
 :::
 

--- a/wiki/geyser/setup/self/paper-spigot.mdx
+++ b/wiki/geyser/setup/self/paper-spigot.mdx
@@ -6,7 +6,7 @@ description: Learn how to set up Geyser on your self-hosted Paper or Spigot serv
 import { Versions } from '@site/src/components/Versions'
 
 :::info
-If your server is running a version earlier than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
+If your server is running a version older than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
 See also [this page](/wiki/geyser/supported-versions/) on supported versions.
 :::
 

--- a/wiki/geyser/setup/self/paper-spigot.mdx
+++ b/wiki/geyser/setup/self/paper-spigot.mdx
@@ -6,7 +6,7 @@ description: Learn how to set up Geyser on your self-hosted Paper or Spigot serv
 import { Versions } from '@site/src/components/Versions'
 
 :::info
-If your server is not running <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
+If your server is running a version earlier than <Versions platform="java"/>, you will need to install <a href="https://viaversion.com/">ViaVersion</a>.
 See also [this page](/wiki/geyser/supported-versions/) on supported versions.
 :::
 


### PR DESCRIPTION
**Text lack of clarity**

In the Setup info box it states:

> If your server is not running 1.21.11, you will need to install [ViaVersion](https://viaversion.com/).

This could be interpreted as meaning ViaVersion is an acceptable route to allowing someone to update to a version higher than 1.21.11 and using ViaVersion to enable GeyserMC to function. This may be especially likely in the case of someone that is very eager to install the latest and greatest update to Minecraft.

**fix**

This tweaks the first part of the text where it states "If your server is not running (latest version Geyser supports here)" with "if your server is running a version older than (latest version Geyser supports here)" to make it clear that ViaVersion is only an option for supporting versions of MC that are earlier than the latest support version, and not an expanded support option for later versions too.

As this is my first request, my apologies if I missed any crucial info to make it better.

If there are other places that need this same change, I would be happy to include them. I didn't see anywhere else with that specific text, though.