### PR TITLE
Update KaasHosting instructions with Geyser auto-install support

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -141,7 +141,7 @@
     "message": "Set the Bedrock port to the Java server's port, or to one of the two extra ports, and connect with that port. If the subdomain doesn't work, use your regular numbered IP address."
   },
   "providers.provider.kaashosting.description": {
-    "message": "Enable `clone-remote-port` in the Geyser config and connect with the Java IP and port, or use an additional port. See [KaasHosting's article](https://www.kaashosting.nl/help/nl/minecraft/hoe-maak-ik-mijn-minecraft-server-crossplay-met-geysermc) for more details."
+    "message": "Automatic and manual installation supported. Go to the `Plugin Installer` tab, search for Geyser and click `Install Automatically`. Connect with the Java IP and port. See [KaasHosting's article](https://www.kaashosting.nl/help/nl/minecraft/hoe-maak-ik-mijn-minecraft-server-crossplay-met-geysermc) for more details."
   },
   "providers.provider.kekshost.description": {
     "message": "Use the default bedrock port (19132) and the server ip to connect on Bedrock edition. No changes to the Geyser config are needed. You can also ask for a new port and use it instead."

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -113,6 +113,14 @@ export const providersData: Providers = {
             })
         },
         {
+            name: 'KaasHosting',
+            url: 'https://www.kaashosting.nl/minecraft-servers',
+            description: translate({
+                id: 'providers.provider.kaashosting.description',
+                message: "Automatic and manual installation supported. Go to the `Plugin Installer` tab, search for Geyser and click `Install Automatically`. Connect with the Java IP and port. See [KaasHosting's article](https://www.kaashosting.nl/help/nl/minecraft/hoe-maak-ik-mijn-minecraft-server-crossplay-met-geysermc) for more details."
+            })
+        },
+        {
             name: 'Lilypad',
             url: 'https://lilypad.gg',
             description: translate({
@@ -455,14 +463,6 @@ export const providersData: Providers = {
             description: translate({
                 id: 'providers.provider.humbleservers.description',
                 message: "Set the Bedrock port to the Java server's port, or to one of the two extra ports, and connect with that port. If the subdomain doesn't work, use your regular numbered IP address."
-            })
-        },
-        {
-            name: 'KaasHosting',
-            url: 'https://www.kaashosting.nl',
-            description: translate({
-                id: 'providers.provider.kaashosting.description',
-                message: "Enable `clone-remote-port` in the Geyser config and connect with the Java IP and port, or use an additional port. See [KaasHosting's article](https://www.kaashosting.nl/help/nl/minecraft/hoe-maak-ik-mijn-minecraft-server-crossplay-met-geysermc) for more details."
             })
         },
         {


### PR DESCRIPTION
KaasHosting now supports one-click Geyser installation through the `Plugin Installer` in the control panel. This PR moves the entry from `support` to `built_in` and updates the installation instructions.