### PR TITLE
Add extensions to dump viewer

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -820,5 +820,50 @@
   "theme.contentVisibility.draftBanner.message": {
     "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
     "description": "The draft content banner message"
+  },
+  "providers.provider.arth_hosting.description": {
+    "message": "Geyser is installed and configured on all servers by default. You can disable it in the 'Manage Plugins' menu."
+  },
+  "providers.provider.mcserverhost.description": {
+    "message": "Under the server configuration, select 'Crossplay' to automatically install Geyser and Floodgate. Join with the connection address. To update Geyser and Floodgate, replace the plugin jars in the server manager and restart the server."
+  },
+  "providers.provider.vemox_hosting.description": {
+    "message": "Full automatic installation. Go to one of the panel options and select the option to enable GeyserMC. Then, restart and connect to your server using your Java IP and port."
+  },
+  "providers.provider.mcforfree.de.description": {
+    "message": "Create an extra port in the game panel, then change the `port` in the `bedrock` section to the newly created port. To connect on Bedrock edition, use the Java server's IP and the port you've created. It may take a few minutes for the port to become active."
+  },
+  "providers.provider.modrinth.description": {
+    "message": "Check [Modrinth's documentation](https://support.modrinth.com/en/articles/10986613-adding-geyser-to-your-server) for specific instructions."
+  },
+  "providers.provider.orionnodes.description": {
+    "message": "Open a port yourself from the network page in the game panel, use that port in the bedrock section of the Geyser config."
+  },
+  "providers.provider.papernodes.description": {
+    "message": "Enable clone-remote-port (or manually set the Bedrock port to the Java port), and connect with the Java IP and port. Alternatively, you can contact the host to request an additional port or a dedicated IP."
+  },
+  "providers.provider.wepwawet.description": {
+    "message": "Add a new port in the Network tab. Use this new port as the bedrock port."
+  },
+  "pages.download.description.offhandextension": {
+    "message": "An extension that allows Bedrock players to switch their offhand and mainhand item by emoting."
+  },
+  "pages.download.description.rainbow": {
+    "message": "A Minecraft mod to generate Geyser item mappings and bedrock resourcepacks for use with Geyser's custom item API (v2)."
+  },
+  "pages.download.description.hydraulic": {
+    "message": "A companion mod to Geyser which allows for Bedrock players to join modded Minecraft: Java Edition servers."
+  },
+  "pages.download.description.thunder": {
+    "message": "A java application to convert simple Java Edition resource packs to Bedrock Edition ones."
+  },
+  "pages.dumpviewer.extensions": {
+    "message": "Extensions"
+  },
+  "pages.dumpviewer.extensions.noextensions": {
+    "message": "No extensions to show."
+  },
+  "pages.dumpviewer.extensions.helptext": {
+    "message": "Click on an extension to view more information."
   }
 }

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -66,5 +66,9 @@
   "logo.alt": {
     "message": "GeyserMC logo",
     "description": "The alt text of footer logo"
+  },
+  "copyright": {
+    "message": "Copyright © 2026 GeyserMC. Built with Docusaurus.<br>This website is not an official Minecraft website and is not associated with Mojang Studios or Microsoft. All product and company names are trademarks or registered trademarks of their respective holders. Use of these names does not imply any affiliation or endorsement by them.",
+    "description": "The footer copyright"
   }
 }

--- a/src/pages/utilities/dump-viewer.tsx
+++ b/src/pages/utilities/dump-viewer.tsx
@@ -8,15 +8,9 @@ import { Grid } from '@site/src/components/Grid';
 import CodeBlock from '@theme/CodeBlock';
 import clsx from 'clsx';
 
-const DumpViewerPage: React.FC = () => {
-    const [dumpId, setDumpId] = useState('');
-    const [data, setData] = useState<any>({});
-    const [statusMessage, setStatusMessage] = useState('');
+const PluginList = ({plugins}, {}) => {
     const [activePlugin, setActivePlugin] = useState<any>({});
-
     const pluginPopoverRef = useRef<any>(null);
-
-    const urlReg = /^(https?:\/\/)?dump\.geysermc\.org/;
 
     useEffect(() => {
         const handleClickOutside = (event) => setActivePlugin({});
@@ -26,6 +20,37 @@ const DumpViewerPage: React.FC = () => {
             document.removeEventListener("mousedown", handleClickOutside);
         };
     }, [pluginPopoverRef]);
+
+    return <Grid elementsPerRow={5}>
+        {plugins.map(plugin => (
+            <div key={plugin.main}>
+                <div onClick={() => setActivePlugin(plugin)} className={styles.pluginName}>
+                    <b>{plugin.name}</b> <div className={styles.pluginEnabledIndicator} style={{ backgroundColor: plugin.enabled ? "green" : "red" }} />
+                </div>
+
+                {activePlugin?.main === plugin.main ? (
+                    <div ref={pluginPopoverRef} className={styles.pluginInfoPopover}>
+                        <p className={styles.pluginNamePopover}>{plugin.name}</p>
+                        <p>{plugin.version}</p>
+                        <p className={styles.pluginEnabled} style={{ backgroundColor: plugin.enabled ? "green" : "red" }}>{plugin.enabled ? "Enabled" : "Disabled"}</p>
+
+                        <p className={styles.pluginAuthorsLabel}>Authors:</p>
+                        <ul>
+                            {plugin.authors.map(author => <li>{author}</li>)}
+                        </ul>
+                    </div>
+                ) : undefined}
+            </div>
+        ))}
+    </Grid>
+};
+
+const DumpViewerPage: React.FC = () => {
+    const [dumpId, setDumpId] = useState('');
+    const [data, setData] = useState<any>({});
+    const [statusMessage, setStatusMessage] = useState('');
+
+    const urlReg = /^(https?:\/\/)?dump\.geysermc\.org/;
 
     useEffect(() => {
         // Get the ID from the URL
@@ -74,10 +99,6 @@ const DumpViewerPage: React.FC = () => {
 
     const capitalizeFirstLetter = (string) => {
         return string.charAt(0).toUpperCase() + string.slice(1)
-    }
-
-    const handlePluginClick = (plugin) => {
-        setActivePlugin(plugin);
     }
 
     return (
@@ -219,28 +240,22 @@ const DumpViewerPage: React.FC = () => {
                                             <>
                                                 <p><Translate id='pages.dumpviewer.plugins.helptext'>Click on a plugin to view more information.</Translate></p>
 
-                                                <Grid elementsPerRow={5}>
-                                                    {data.bootstrapInfo.plugins.map(plugin => (
-                                                        <div>
-                                                            <b onClick={() => handlePluginClick(plugin)} className={styles.pluginName}>
-                                                                {plugin.name} <div className={styles.pluginEnabledIndicator} style={{ backgroundColor: plugin.enabled ? "green" : "red" }} />
-                                                            </b>
+                                                <PluginList plugins={data.bootstrapInfo.plugins}></PluginList>
+                                            </>
+                                        )}
+                                    </div>
+                                </div>
+                                <div className={styles.card}>
+                                    <div className={styles.cardHeader}>
+                                        <Translate id='pages.dumpviewer.extensions'>Extensions</Translate> ({data.extensionInfo?.length ?? 0})
+                                    </div>
+                                    <div className={styles.cardBody}>
+                                        {!data.extensionInfo || data.extensionInfo.length === 0 ? (
+                                            <p><Translate id='pages.dumpviewer.extensions.noextensions'>No extensions to show.</Translate></p>) : (
+                                            <>
+                                                <p><Translate id='pages.dumpviewer.extensions.helptext'>Click on an extension to view more information.</Translate></p>
 
-                                                            {activePlugin?.main === plugin.main ? (
-                                                                <div ref={pluginPopoverRef} className={styles.pluginInfoPopover}>
-                                                                    <p className={styles.pluginNamePopover}>{plugin.name}</p>
-                                                                    <p>{plugin.version}</p>
-                                                                    <p className={styles.pluginEnabled} style={{ backgroundColor: plugin.enabled ? "green" : "red" }}>{plugin.enabled ? "Enabled" : "Disabled"}</p>
-
-                                                                    <p className={styles.pluginAuthorsLabel}>Authors:</p>
-                                                                    <ul>
-                                                                        {plugin.authors.map(author => <li>{author}</li>)}
-                                                                    </ul>
-                                                                </div>
-                                                            ) : undefined}
-                                                        </div>
-                                                    ))}
-                                                </Grid>
+                                                <PluginList plugins={data.extensionInfo}></PluginList>
                                             </>
                                         )}
                                     </div>


### PR DESCRIPTION
This PR does what it says, it adds extension information to the website's dump viewer. Re-uses the plugin list code, makes it into its own component.

<img width="1293" height="403" alt="image" src="https://github.com/user-attachments/assets/ab4a9d57-ff24-420d-8736-12d9a58311b5" />

Not sure if I updated the translations correctly.
