### PR TITLE
Remove high resolution items link from the Custom Items wiki page

### DIFF
--- a/wiki/geyser/custom-items.mdx
+++ b/wiki/geyser/custom-items.mdx
@@ -839,7 +839,6 @@ For example, an item registered with the Bedrock identifier `example:yummy_food`
 ### Further references:
 - [Minecraft creator docs on texture pack conversion](https://learn.microsoft.com/en-us/minecraft/creator/documents/convertingtexturepacks?view=minecraft-bedrock-stable)
 - [Creating textures for custom items](https://wiki.bedrock.dev/items/items-intro#applying-textures)
-- [High resolution items](https://wiki.bedrock.dev/items/high-resolution-items)
 
 ## Loading mappings and resource packs
 This section assumes you already set up and configured Geyser so Bedrock players are able to connect. Further, the `enable-custom-content`


### PR DESCRIPTION
This PR does what the title says.