### PR TITLE
Update Geyser API version

### DIFF
--- a/wiki/geyser/getting-started-with-the-api.md
+++ b/wiki/geyser/getting-started-with-the-api.md
@@ -32,7 +32,7 @@ Add Geyser's API codebase as a dependency:
 <dependency>
     <groupId>org.geysermc.geyser</groupId>
     <artifactId>api</artifactId>
-    <version>2.9.5-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -40,7 +40,7 @@ Add Geyser's API codebase as a dependency:
 **Gradle**
 ```groovy
 dependencies {
-    compileOnly('org.geysermc.geyser:api:2.9.5-SNAPSHOT')
+    compileOnly('org.geysermc.geyser:api:2.10.0-SNAPSHOT')
 }
 ```
 


### PR DESCRIPTION
This PR updates the Geyser API version on the [Getting Started with the API](https://geysermc.org/wiki/geyser/getting-started-with-the-api) wiki page.