### PR TITLE
Indicate Minecraft: Bedrock Edition 26.31 and 26.32 support

### DIFF
--- a/src/data/versions.json
+++ b/src/data/versions.json
@@ -1,9 +1,9 @@
 {
     "bedrock": {
-        "supported": "26.0-26.30",
+        "supported": "26.0-26.32",
         "latest": {
             "id": 1001,
-            "name": "26.30"
+            "name": "26.32"
         }
     },
     "java": {


### PR DESCRIPTION
This pull request does the following:
- Update the supported Minecraft: Bedrock Edition range in versions.json.
- Update the latest Minecraft: Bedrock Edition from Minecraft: Bedrock Edition 26.30 to Minecraft: Bedrock Edition 26.32 in versions.json.