### PR TITLE
Indicate Minecraft: Bedrock Edition 26.33 support

### DIFF
--- a/src/data/versions.json
+++ b/src/data/versions.json
@@ -1,9 +1,9 @@
 {
     "bedrock": {
-        "supported": "26.0-26.32",
+        "supported": "26.0-26.33",
         "latest": {
             "id": 1001,
-            "name": "26.32"
+            "name": "26.33"
         }
     },
     "java": {


### PR DESCRIPTION
This pull request updates the versions.json to include Minecraft: Bedrock Edition 26.33.