### PR TITLE
Add TrueTick to the built-in hosting providers

### DIFF
--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -222,6 +222,14 @@ export const providersData: Providers = {
             })
         },
         {
+            name: 'TrueTick',
+            url: 'https://truetick.gg/',
+            description: translate({
+                id: 'providers.provider.truetick.description',
+                message: "Turn on Bedrock crossplay in Settings: Geyser and Floodgate are installed and the Bedrock port is opened together. Restart once, then give Bedrock players the address shown on the panel's Connect line - the same hostname as Java on a different port, not 19132 from the outside. Offered on plain Paper and Purpur servers on the flat plan. See [TrueTick's article](https://truetick.gg/help/connect-and-share#bedrock-crossplay) for more details."
+            })
+        },
+        {
             name: 'UltraServers',
             url: 'https://ultraservers.com/',
             description: translate({


### PR DESCRIPTION
Adds TrueTick (https://truetick.gg) to `built_in`.

Turning on **Bedrock crossplay** in the panel installs Geyser and Floodgate and opens the Bedrock UDP port in one action, which matches CONTRIBUTING's definition of `built_in` ("fully automatic Geyser installation").

The description states the two conditions the platform actually enforces, so nobody follows it onto a server where it is not offered:

- the server has to be plain Paper or Purpur (that is exactly what the bundle can install), and
- it is offered on the flat plan only — on the usage-billed plan a sleeping server is woken by a Java handshake, and a Bedrock/RakNet packet cannot do that.

It also points out that the external port is **not** 19132: the platform derives a per-server port and shows it on the panel's Connect line. That is the detail users get wrong most often.

Placed in alphabetical order between SRKHOST and UltraServers. Only `src/data/providers.ts` is touched and the change is a single entry in the existing shape, so the extraction logic in `create-providers-json.ts` is unaffected.