### PR TITLE
Add Supercraft to supported hosting providers

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -191,6 +191,9 @@
   "providers.provider.stipe.description": {
     "message": "Set the Bedrock port to the Java server's port and connect with that port; note that this provider only provides service in Australia."
   },
+  "providers.provider.supercraft.description": {
+    "message": "Upload Geyser-Spigot and Floodgate into the Plugins partition of the file manager and restart once to generate the config. Then set the Bedrock port to your server port + 2 (the server port itself is taken by Java and the query listener, the next one by RCON), bind address 0.0.0.0, point remote.port at your server port, and restart; connect Bedrock clients to that +2 port. Full steps: [Supercraft Geyser guide](https://supercraft.host/wiki/minecraft/geyser_setup/#supercraft)."
+  },
   "providers.provider.syntexhosting.description": {
     "message": "Set the Bedrock port to the Java server's port and connect with that port, or request a (free) additional port."
   },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -192,7 +192,7 @@
     "message": "Set the Bedrock port to the Java server's port and connect with that port; note that this provider only provides service in Australia."
   },
   "providers.provider.supercraft.description": {
-    "message": "Upload Geyser-Spigot and Floodgate into the Plugins partition of the file manager and restart once to generate the config. Then set the Bedrock port to your server port + 2 (the server port itself is taken by Java and the query listener, the next one by RCON), bind address 0.0.0.0, point remote.port at your server port, and restart; connect Bedrock clients to that +2 port. Full steps: [Supercraft Geyser guide](https://supercraft.host/wiki/minecraft/geyser_setup/#supercraft)."
+    "message": "Set the Bedrock port to your server port + 2. The server port itself is used by Java and the query listener, and the next one by RCON. Upload Geyser and Floodgate in the panel, restart, then connect on that +2 port. [Setup guide](https://supercraft.host/wiki/minecraft/geyser_setup/#supercraft)."
   },
   "providers.provider.syntexhosting.description": {
     "message": "Set the Bedrock port to the Java server's port and connect with that port, or request a (free) additional port."

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -608,6 +608,14 @@ export const providersData: Providers = {
             })
         },
         {
+            name: 'Supercraft',
+            url: 'https://supercraft.host/',
+            description: translate({
+                id: 'providers.provider.supercraft.description',
+                message: "Upload Geyser-Spigot and Floodgate into the Plugins partition of the file manager and restart once to generate the config. Then set the Bedrock port to your server port + 2 (the server port itself is taken by Java and the query listener, the next one by RCON), bind address 0.0.0.0, point remote.port at your server port, and restart; connect Bedrock clients to that +2 port. Full steps: [Supercraft Geyser guide](https://supercraft.host/wiki/minecraft/geyser_setup/#supercraft)."
+            })
+        },
+        {
             name: 'The Minecraft Hosting',
             url: 'https://theminecrafthosting.com/',
             description: translate({

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -612,7 +612,7 @@ export const providersData: Providers = {
             url: 'https://supercraft.host/',
             description: translate({
                 id: 'providers.provider.supercraft.description',
-                message: "Upload Geyser-Spigot and Floodgate into the Plugins partition of the file manager and restart once to generate the config. Then set the Bedrock port to your server port + 2 (the server port itself is taken by Java and the query listener, the next one by RCON), bind address 0.0.0.0, point remote.port at your server port, and restart; connect Bedrock clients to that +2 port. Full steps: [Supercraft Geyser guide](https://supercraft.host/wiki/minecraft/geyser_setup/#supercraft)."
+                message: "Set the Bedrock port to your server port + 2. The server port itself is used by Java and the query listener, and the next one by RCON. Upload Geyser and Floodgate in the panel, restart, then connect on that +2 port. [Setup guide](https://supercraft.host/wiki/minecraft/geyser_setup/#supercraft)."
             })
         },
         {


### PR DESCRIPTION
Adds Supercraft (https://supercraft.host/) to the `support` list in `src/data/providers.ts`, with the matching key in `i18n/en/code.json`, in alphabetical order after STIPE per CONTRIBUTING.md.

