### PR TITLE
Indicate Minecraft: Bedrock Edition 26.45 support

### DIFF
--- a/src/data/versions.json
+++ b/src/data/versions.json
@@ -1,9 +1,9 @@
 {
     "bedrock": {
-        "supported": "26.0-26.40",
+        "supported": "26.0-26.45",
         "latest": {
             "id": 2168,
-            "name": "26.40"
+            "name": "26.45"
         }
     },
     "java": {

--- a/src/data/versions.json
+++ b/src/data/versions.json
@@ -2,7 +2,7 @@
     "bedrock": {
         "supported": "26.0-26.45",
         "latest": {
-            "id": 2168,
+            "id": 2169,
             "name": "26.45"
         }
     },


### PR DESCRIPTION
This pull request updates the versions.json to include Minecraft: Bedrock Edition 26.45.

Closes #180 